### PR TITLE
rename ctor with postfix

### DIFF
--- a/viu-test/src/main.rs
+++ b/viu-test/src/main.rs
@@ -14,16 +14,31 @@ struct Fuck {
 }
 
 fn foo(f: &mut Fuck) {
-    *FuckViewA!(f).a += 1;
-    dbg!(FuckViewB!(f).b);
-    let mut a_b = FuckViewAAndB!(f);
+    *FuckViewA_ctor!(f).a += 1;
+    dbg!(FuckViewB_ctor!(f).b);
+    let mut a_b = FuckViewAAndB_ctor!(f);
     *a_b.b += "123";
     bar(a_b.reborrow())
 }
 
 fn bar(mut a_b: FuckViewAAndB) {
-    *FuckViewA!(a_b).a += 2;
-    dbg!(FuckViewB!(a_b).b);
+    *FuckViewA_ctor!(a_b).a += 2;
+    dbg!(FuckViewB_ctor!(a_b).b);
+}
+
+
+mod inner {
+
+    use super::{Fuck, FuckViewB};
+    #[allow(dead_code)]
+    fn assert_expend_macro() {
+        let fuck = Fuck {
+            a: 0,
+            b: "".to_string()
+        };
+
+        FuckViewB_ctor!(fuck);
+    }
 }
 
 fn main() {

--- a/viu/src/lib.rs
+++ b/viu/src/lib.rs
@@ -202,6 +202,7 @@ fn construct_view_type(
         .collect::<Vec<_>>();
 
     quote::quote! {
+        #[allow(snake_case)]
         #vis struct #view_name <#ref_lifetime, #mut_lifetime, #(#gens,)*>
         #where_clause
         {
@@ -259,6 +260,7 @@ fn construct_view_type_ctor(
     fields: &HashMap<String, (syn::Visibility, Sharable, syn::Type)>,
 ) -> TokenStream {
     let view_name = syn::Ident::new(view_name, Span::call_site());
+    let ctor_name = syn::Ident::new(&format!("{view_name}_ctor"), Span::call_site());
     let fields = fields
         .iter()
         .map(|(field_name, (_, share, _))| {
@@ -276,7 +278,7 @@ fn construct_view_type_ctor(
 
     quote::quote! {
         #[macro_export]
-        macro_rules! #view_name {
+        macro_rules! #ctor_name {
             ($e: expr) => {
                 #view_name {
                     #(#fields,)*


### PR DESCRIPTION
macro与view type重名，将会被禁止。之后marco后加一个_ctor的后缀